### PR TITLE
Implementation of item index page

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,7 @@
 | shipping_fee_id    | integer    | null: false                    |
 | shipping_origin_id | integer    | null: false                    |
 | shipping_date_id   | integer    | null: false                    |
+| purchase_status    | boolean    | null: false                    |
 | user               | references | null: false, foreign_key: true |
 
 ### Association

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -3,6 +3,7 @@ class ItemsController < ApplicationController
 
   # トップページ
   def index
+    @items = Item.all.order(created_at: "DESC")
   end
 
   # 商品出品ページ

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -3,7 +3,7 @@ class ItemsController < ApplicationController
 
   # トップページ
   def index
-    @items = Item.all.order(created_at: "DESC")
+    @items = Item.all.order(created_at: 'DESC')
   end
 
   # 商品出品ページ

--- a/app/views/items/index.html.erb
+++ b/app/views/items/index.html.erb
@@ -133,9 +133,11 @@
           <%= image_tag item.image, class: "item-img" %>
 
           <%# 商品が売れていればsold outの表示 %>
+          <% if item.purchase_status then %>
           <div class='sold-out'>
             <span>Sold Out!!</span>
           </div>
+          <% end %>
           <%# //商品が売れていればsold outの表示 %>
 
         </div>

--- a/app/views/items/index.html.erb
+++ b/app/views/items/index.html.erb
@@ -132,13 +132,11 @@
         <div class='item-img-content'>
           <%= image_tag item.image, class: "item-img" %>
 
-          <%# 商品が売れていればsold outの表示 %>
           <% if item.purchase_status then %>
           <div class='sold-out'>
             <span>Sold Out!!</span>
           </div>
           <% end %>
-          <%# //商品が売れていればsold outの表示 %>
 
         </div>
         <div class='item-info'>

--- a/app/views/items/index.html.erb
+++ b/app/views/items/index.html.erb
@@ -126,11 +126,11 @@
     <%= link_to '新規投稿商品', "#", class: "subtitle" %>
     <ul class='item-lists'>
 
-      <%# 商品のインスタンス変数になにか入っている場合、中身のすべてを展開できるようにしましょう %>
+      <% @items.each do |item| %>
       <li class='list'>
         <%= link_to "#" do %>
         <div class='item-img-content'>
-          <%= image_tag "item-sample.png", class: "item-img" %>
+          <%= image_tag item.image, class: "item-img" %>
 
           <%# 商品が売れていればsold outの表示 %>
           <div class='sold-out'>
@@ -141,10 +141,10 @@
         </div>
         <div class='item-info'>
           <h3 class='item-name'>
-            <%= "商品名" %>
+            <%= item.name %>
           </h3>
           <div class='item-price'>
-            <span><%= "販売価格" %>円<br>(税込み)</span>
+            <span><%= item.price %>円<br>(税込み)</span>
             <div class='star-btn'>
               <%= image_tag "star.png", class:"star-icon" %>
               <span class='star-count'>0</span>
@@ -153,10 +153,10 @@
         </div>
         <% end %>
       </li>
-      <%# //商品のインスタンス変数になにか入っている場合、中身のすべてを展開できるようにしましょう %>
+      <% end %>
 
       <%# 商品がない場合のダミー %>
-      <%# 商品がある場合は表示されないようにしましょう %>
+      <% unless @items.present? %>
       <li class='list'>
         <%= link_to '#' do %>
         <%= image_tag "https://s3-ap-northeast-1.amazonaws.com/mercarimaster/uploads/captured_image/content/10/a004.png", class: "item-img" %>
@@ -174,7 +174,7 @@
         </div>
         <% end %>
       </li>
-      <%# //商品がある場合は表示されないようにしましょう %>
+      <% end %>
       <%# //商品がない場合のダミー %>
     </ul>
   </div>

--- a/db/migrate/20200811061410_add_purchase_status_to_item.rb
+++ b/db/migrate/20200811061410_add_purchase_status_to_item.rb
@@ -1,0 +1,5 @@
+class AddPurchaseStatusToItem < ActiveRecord::Migration[6.0]
+  def change
+    add_column :items, :purchase_status, :boolean, default: false, null: false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_08_09_092245) do
+ActiveRecord::Schema.define(version: 2020_08_11_061410) do
 
   create_table "active_storage_attachments", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
     t.string "name", null: false
@@ -45,6 +45,7 @@ ActiveRecord::Schema.define(version: 2020_08_09_092245) do
     t.bigint "user_id", null: false
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
+    t.boolean "purchase_status", default: false, null: false
     t.index ["user_id"], name: "index_items_on_user_id"
   end
 


### PR DESCRIPTION
# What
- 出品商品の一覧表示機能
- 出品商品無し時のダミー商品表示
- 購入された商品の"sold out"表示機能（Itemモデルへのpurchase_statusカラム追加）

# Why
- 商品一覧表示機能実装のため。

# Reference
- 出品商品がない場合
[![Image from Gyazo](https://i.gyazo.com/e5d3b452ffc703dd8d6a6e8b40dba939.png)](https://gyazo.com/e5d3b452ffc703dd8d6a6e8b40dba939)
- 出品商品がある場合（1点は購入済みの状態）
[![Image from Gyazo](https://i.gyazo.com/2c9791862b2c885bc87d6b383bcf058c.png)](https://gyazo.com/2c9791862b2c885bc87d6b383bcf058c)